### PR TITLE
Configure GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,57 @@
+on: [push, pull_request]
+name: build
+jobs:
+  extended-reals:
+    name: extended-reals
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        ghc: ['8.4.4', '8.6.5', '8.8.4', '8.10.2']
+        os: [ubuntu-latest]
+        include:
+          - ghc: '8.4.4'
+            resolver: 'lts-12.26'
+            flags: ''
+          - ghc: '8.6.5'
+            resolver: 'lts-14.27'
+            flags: ''
+          - ghc: '8.8.4'
+            resolver: 'lts-16.27'
+            coveralls: true
+            flags: '--coverage'
+          - ghc: '8.10.2'
+            resolver: 'nightly-2020-11-01'
+            flags: ''
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: haskell/actions/setup@v1
+        name: Setup Haskell
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          enable-stack: true
+          stack-version: 'latest'
+          stack-no-global: true
+          stack-setup-ghc: true
+
+      - uses: actions/cache@v1
+        name: Cache ~/.stack
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-${{ matrix.ghc }}-stack
+
+      - name: Build
+        run: |
+          echo "resolver: ${{ matrix.resolver }}" > stack.yaml
+          stack build --test --no-run-tests --bench --no-run-benchmarks ${{ matrix.flags }}
+      - name: Test
+        run: stack test ${{ matrix.flags }}
+
+      - name: Coveralls
+        if: matrix.coveralls
+        continue-on-error: true
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: |
+          curl -L https://github.com/lehins/stack-hpc-coveralls/releases/download/v0.0.6.0/shc.tar.gz | tar -xz
+          ./shc --repo-token="$COVERALLS_REPO_TOKEN" extended-reals TestExtendedReal

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,8 +44,12 @@ jobs:
         run: |
           echo "resolver: ${{ matrix.resolver }}" > stack.yaml
           stack build --test --no-run-tests --bench --no-run-benchmarks ${{ matrix.flags }}
+
       - name: Test
         run: stack test ${{ matrix.flags }}
+
+      - name: Create source tarball
+        run: stack sdist ${{ matrix.flags }}
 
       - name: Coveralls
         if: matrix.coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.18 GHCVER=7.8.4 COVERAGE=1
+    - env: CABALVER=1.18 GHCVER=7.8.4
       compiler: ": #GHC 7.8.4"
       addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4,alex-3.1.4,happy-1.19.5], sources: [hvr-ghc]}}
     - env: CABALVER=1.22 GHCVER=7.10.3

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ extended-reals
 
 [![Build Status (Travis CI)](https://secure.travis-ci.org/msakai/extended-reals.png?branch=master)](http://travis-ci.org/msakai/extended-reals) 
 [![Build Status (AppVeyor)](https://ci.appveyor.com/api/projects/status/r9v6hp2gldge2jih?svg=true)](https://ci.appveyor.com/project/msakai/extended-reals)
+[![Build Status (GitHub Actions)](https://github.com/msakai/extended-reals/workflows/build/badge.svg)](https://github.com/msakai/extended-reals/actions)
 [![Hackage](https://img.shields.io/hackage/v/extended-reals.svg)](https://hackage.haskell.org/package/extended-reals)
 [![Coverage Status](https://coveralls.io/repos/msakai/extended-reals/badge.svg?branch=master)](https://coveralls.io/r/msakai/extended-reals?branch=master)
 [![Hackage Deps](https://img.shields.io/hackage-deps/v/extended-reals.svg)](https://packdeps.haskellers.com/feed?needle=extended-reals)


### PR DESCRIPTION
This configure GitHub Actions and use it for submitting coverage information to coveralls.io instead of Travis-CI.

This is to prepare for the transition from Travis-CI to GitHub Actions.